### PR TITLE
Add ToolPaths serialization utilities

### DIFF
--- a/noether_gui/src/widgets/tpp_widget.cpp
+++ b/noether_gui/src/widgets/tpp_widget.cpp
@@ -12,6 +12,7 @@
 #include <QStandardPaths>
 #include <QTextStream>
 #include <yaml-cpp/yaml.h>
+#include <noether_tpp/core/serialization.h>
 
 // Rendering includes
 #ifndef VTK_MAJOR_VERSION
@@ -563,53 +564,17 @@ void TPPWidget::onSaveToolPath(const bool /*checked*/)
   if (!file.endsWith(".yaml"))
     file = file.append(".yaml");
 
-    try
+  try
   {
-    // Open output file
     std::ofstream out(file.toStdString());
     if (!out)
       throw std::runtime_error("Failed to open file for writing: " + file.toStdString());
 
-    // Write waypoints one at a time
-    for (const auto& fragment : tool_paths_)
-    {
-      for (const auto& path : fragment)
-      {
-        for (const auto& segment : path)
-        {
-          for (const auto& pose : segment)
-          {
-            // Write header
-
-            out << "---\n"; 
-            out << "header:\n";
-            out << "  stamp:\n";
-            out << "    sec: 0\n";
-            out << "    nanosec: 0\n";
-            out << "  frame_id: world\n";
-
-            // Write pose
-            out << "pose:\n";
-            out << "  position:\n";
-            out << "    x: " << pose.translation().x() << "\n";
-            out << "    y: " << pose.translation().y() << "\n";
-            out << "    z: " << pose.translation().z() << "\n";
-
-            // Convert rotation matrix to quaternion and write orientation
-            Eigen::Quaterniond q(pose.rotation());
-            out << "  orientation:\n";
-            out << "    x: " << q.x() << "\n";
-            out << "    y: " << q.y() << "\n";
-            out << "    z: " << q.z() << "\n";
-            out << "    w: " << q.w() << "\n";
-          }
-        }
-      }
-    }
-      }
+    out << tool_paths_;
+  }
   catch (const std::exception& ex)
   {
-        std::stringstream ss;
+    std::stringstream ss;
     printException(ex, ss);
     QMessageBox::warning(this, "Save Error", QString::fromStdString(ss.str()));
   }

--- a/noether_tpp/include/noether_tpp/core/serialization.h
+++ b/noether_tpp/include/noether_tpp/core/serialization.h
@@ -1,0 +1,142 @@
+#pragma once
+
+#include <cxxabi.h>
+#include <Eigen/Dense>
+#include <yaml-cpp/yaml.h>
+#include <stdexcept>
+#include <string>
+#include <typeinfo>
+#include <ostream>
+#include <noether_tpp/core/types.h>
+
+namespace noether
+{
+
+/**
+ * @brief Helper for extracting values from a YAML node
+ */
+template <typename T>
+inline T getMember(const YAML::Node& n, const std::string& key)
+{
+  try
+  {
+    T value = n[key].as<T>();
+    return value;
+  }
+  catch (const YAML::BadConversion&)
+  {
+    int status;
+    std::string name(abi::__cxa_demangle(typeid(T).name(), 0, 0, &status));
+    throw std::runtime_error("Failed to convert parameter '" + key + "' to type '" + name + "'");
+  }
+  catch (const YAML::Exception&)
+  {
+    int status;
+    std::string name(abi::__cxa_demangle(typeid(T).name(), 0, 0, &status));
+    throw std::runtime_error("Failed to find '" + key + "' parameter of type '" + name + "'");
+  }
+}
+
+}  // namespace noether
+
+namespace YAML
+{
+using noether::getMember;
+
+template <typename FloatT>
+struct convert<Eigen::Matrix<FloatT, 2, 1>>
+{
+  using T = Eigen::Matrix<FloatT, 2, 1>;
+
+  static Node encode(const T& val)
+  {
+    YAML::Node node;
+    node["x"] = val.x();
+    node["y"] = val.y();
+    return node;
+  }
+
+  static bool decode(const YAML::Node& node, T& val)
+  {
+    val.x() = getMember<FloatT>(node, "x");
+    val.y() = getMember<FloatT>(node, "y");
+
+    return true;
+  }
+};
+
+template <typename FloatT>
+struct convert<Eigen::Matrix<FloatT, 3, 1>>
+{
+  using T = Eigen::Matrix<FloatT, 3, 1>;
+
+  static Node encode(const T& val)
+  {
+    YAML::Node node;
+    node["x"] = val.x();
+    node["y"] = val.y();
+    node["z"] = val.z();
+    return node;
+  }
+
+  static bool decode(const YAML::Node& node, T& val)
+  {
+    val.x() = getMember<FloatT>(node, "x");
+    val.y() = getMember<FloatT>(node, "y");
+    val.z() = getMember<FloatT>(node, "z");
+
+    return true;
+  }
+};
+
+template <typename FloatT>
+struct convert<Eigen::Transform<FloatT, 3, Eigen::Isometry>>
+{
+  using T = Eigen::Transform<FloatT, 3, Eigen::Isometry>;
+
+  static Node encode(const T& val)
+  {
+    YAML::Node node;
+    node["x"] = val.translation().x();
+    node["y"] = val.translation().y();
+    node["z"] = val.translation().z();
+
+    Eigen::Quaternion<FloatT> quat(val.linear());
+    node["qw"] = quat.w();
+    node["qx"] = quat.x();
+    node["qy"] = quat.y();
+    node["qz"] = quat.z();
+
+    return node;
+  }
+
+  static bool decode(const YAML::Node& node, T& val)
+  {
+    Eigen::Matrix<FloatT, 3, 1> trans;
+    trans.x() = getMember<FloatT>(node, "x");
+    trans.y() = getMember<FloatT>(node, "y");
+    trans.z() = getMember<FloatT>(node, "z");
+
+    Eigen::Quaternion<FloatT> quat;
+    quat.w() = getMember<FloatT>(node, "qw");
+    quat.x() = getMember<FloatT>(node, "qx");
+    quat.y() = getMember<FloatT>(node, "qy");
+    quat.z() = getMember<FloatT>(node, "qz");
+
+    val = Eigen::Translation<FloatT, 3>(trans) * quat;
+
+    return true;
+  }
+};
+
+}  // namespace YAML
+
+namespace noether
+{
+inline std::ostream& operator<<(std::ostream& os, const ToolPaths& paths)
+{
+  YAML::Node node(paths);
+  os << node;
+  return os;
+}
+}  // namespace noether


### PR DESCRIPTION
## Summary
- include tool path types in `serialization.h`
- write tool paths directly with `operator<<`

## Testing
- `colcon build --cmake-args -DCMAKE_BUILD_TYPE=Debug -DNOETHER_ENABLE_TESTING=ON -DNOETHER_ENABLE_RUN_TESTING=OFF` *(fails: `colcon` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840f1b431a8832094b03031d3c4faad