### PR TITLE
Add ROS2 tool path planning server

### DIFF
--- a/noether_tpp_server/CMakeLists.txt
+++ b/noether_tpp_server/CMakeLists.txt
@@ -1,0 +1,27 @@
+cmake_minimum_required(VERSION 3.5.1)
+
+find_package(ros_industrial_cmake_boilerplate REQUIRED)
+extract_package_metadata(pkg)
+
+project(${pkg_extracted_name} VERSION ${pkg_extracted_version} LANGUAGES C CXX)
+
+find_package(rclcpp REQUIRED)
+find_package(rosidl_default_generators REQUIRED)
+find_package(yaml-cpp REQUIRED)
+find_package(noether_gui REQUIRED)
+
+# generate service
+rosidl_generate_interfaces(${PROJECT_NAME}
+  "srv/PlanToolPath.srv"
+)
+
+add_executable(${PROJECT_NAME}_node src/tool_path_planner_server.cpp)
+target_link_libraries(${PROJECT_NAME}_node PUBLIC rclcpp::rclcpp yaml-cpp noether::noether_gui)
+
+# Set C++ standard and other compile options
+target_cxx_version(${PROJECT_NAME}_node PUBLIC VERSION 14)
+target_clang_tidy(${PROJECT_NAME}_node ENABLE ${NOETHER_ENABLE_CLANG_TIDY} WARNINGS_AS_ERRORS ${NOETHER_ENABLE_TESTING} CHECKS ${DEFAULT_CLANG_TIDY_CHECKS})
+
+install(TARGETS ${PROJECT_NAME}_node DESTINATION lib/${PROJECT_NAME})
+
+configure_package(NAMESPACE noether TARGETS ${PROJECT_NAME}_node DEPENDENCIES rclcpp rosidl_default_runtime yaml-cpp noether_gui)

--- a/noether_tpp_server/CMakeLists.txt
+++ b/noether_tpp_server/CMakeLists.txt
@@ -1,27 +1,32 @@
-cmake_minimum_required(VERSION 3.5.1)
+cmake_minimum_required(VERSION 3.8)
 
-find_package(ros_industrial_cmake_boilerplate REQUIRED)
-extract_package_metadata(pkg)
+project(noether_tpp_server LANGUAGES CXX)
 
-project(${pkg_extracted_name} VERSION ${pkg_extracted_version} LANGUAGES C CXX)
-
+find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 find_package(yaml-cpp REQUIRED)
 find_package(noether_gui REQUIRED)
+find_package(boost_plugin_loader REQUIRED)
 
-# generate service
 rosidl_generate_interfaces(${PROJECT_NAME}
   "srv/PlanToolPath.srv"
 )
 
-add_executable(${PROJECT_NAME}_node src/tool_path_planner_server.cpp)
-target_link_libraries(${PROJECT_NAME}_node PUBLIC rclcpp::rclcpp yaml-cpp noether::noether_gui)
+add_executable(tool_path_planner_server src/tool_path_planner_server.cpp)
+ament_target_dependencies(tool_path_planner_server
+  rclcpp
+  yaml-cpp
+  noether_gui
+  boost_plugin_loader
+)
 
-# Set C++ standard and other compile options
-target_cxx_version(${PROJECT_NAME}_node PUBLIC VERSION 14)
-target_clang_tidy(${PROJECT_NAME}_node ENABLE ${NOETHER_ENABLE_CLANG_TIDY} WARNINGS_AS_ERRORS ${NOETHER_ENABLE_TESTING} CHECKS ${DEFAULT_CLANG_TIDY_CHECKS})
+rosidl_target_interfaces(tool_path_planner_server
+  ${PROJECT_NAME} "rosidl_typesupport_cpp")
 
-install(TARGETS ${PROJECT_NAME}_node DESTINATION lib/${PROJECT_NAME})
+install(TARGETS tool_path_planner_server
+  DESTINATION lib/${PROJECT_NAME})
 
-configure_package(NAMESPACE noether TARGETS ${PROJECT_NAME}_node DEPENDENCIES rclcpp rosidl_default_runtime yaml-cpp noether_gui)
+ament_export_dependencies(rosidl_default_runtime)
+
+ament_package()

--- a/noether_tpp_server/colcon.pkg
+++ b/noether_tpp_server/colcon.pkg
@@ -1,0 +1,3 @@
+{
+    "hooks": ["share/noether_tpp_server/hook/ament_prefix_path.dsv", "share/noether_tpp_server/hook/ros_package_path.dsv"]
+}

--- a/noether_tpp_server/package.xml
+++ b/noether_tpp_server/package.xml
@@ -7,16 +7,18 @@
   <maintainer email="example@todo.com">TODO Maintainer</maintainer>
   <license>Apache 2.0</license>
 
-  <build_depend>ros_industrial_cmake_boilerplate</build_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
   <build_depend>rclcpp</build_depend>
   <build_depend>rosidl_default_generators</build_depend>
   <build_depend>yaml-cpp</build_depend>
   <build_depend>noether_gui</build_depend>
+  <build_depend>boost_plugin_loader</build_depend>
 
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
   <exec_depend>yaml-cpp</exec_depend>
   <exec_depend>noether_gui</exec_depend>
+  <exec_depend>boost_plugin_loader</exec_depend>
 
   <member_of_group>rosidl_interface_packages</member_of_group>
 

--- a/noether_tpp_server/package.xml
+++ b/noether_tpp_server/package.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>noether_tpp_server</name>
+  <version>0.1.0</version>
+  <description>ROS2 service server for noether tool path planner</description>
+
+  <maintainer email="example@todo.com">TODO Maintainer</maintainer>
+  <license>Apache 2.0</license>
+
+  <build_depend>ros_industrial_cmake_boilerplate</build_depend>
+  <build_depend>rclcpp</build_depend>
+  <build_depend>rosidl_default_generators</build_depend>
+  <build_depend>yaml-cpp</build_depend>
+  <build_depend>noether_gui</build_depend>
+
+  <exec_depend>rclcpp</exec_depend>
+  <exec_depend>rosidl_default_runtime</exec_depend>
+  <exec_depend>yaml-cpp</exec_depend>
+  <exec_depend>noether_gui</exec_depend>
+
+  <member_of_group>rosidl_interface_packages</member_of_group>
+
+  <export>
+    <build_type>cmake</build_type>
+  </export>
+</package>

--- a/noether_tpp_server/src/tool_path_planner_server.cpp
+++ b/noether_tpp_server/src/tool_path_planner_server.cpp
@@ -1,0 +1,123 @@
+#include <rclcpp/rclcpp.hpp>
+#include <noether_gui/widgets/configurable_tpp_pipeline_widget.h>
+#include <noether_tpp/core/tool_path_planner_pipeline.h>
+#include <noether_tpp/core/types.h>
+#include <boost_plugin_loader/plugin_loader.h>
+#include <fstream>
+#include <pcl/io/vtk_lib_io.h>
+#include <yaml-cpp/yaml.h>
+#include <QApplication>
+
+#include "noether_tpp_server/srv/plan_tool_path.hpp"
+
+namespace noether_tpp_server
+{
+
+namespace
+{
+YAML::Node toYaml(const std::vector<noether::ToolPaths>& paths)
+{
+  YAML::Node root;
+  for (const auto& tps : paths)
+  {
+    YAML::Node tps_node;
+    for (const auto& tp : tps)
+    {
+      YAML::Node tp_node;
+      for (const auto& seg : tp)
+      {
+        YAML::Node seg_node;
+        for (const auto& wp : seg)
+        {
+          Eigen::Quaterniond q(wp.linear());
+          YAML::Node wp_node;
+          wp_node["x"] = wp.translation().x();
+          wp_node["y"] = wp.translation().y();
+          wp_node["z"] = wp.translation().z();
+          wp_node["qx"] = q.x();
+          wp_node["qy"] = q.y();
+          wp_node["qz"] = q.z();
+          wp_node["qw"] = q.w();
+          seg_node.push_back(wp_node);
+        }
+        tp_node.push_back(seg_node);
+      }
+      tps_node.push_back(tp_node);
+    }
+    root.push_back(tps_node);
+  }
+  return root;
+}
+}  // namespace
+
+class ToolPathPlannerServer : public rclcpp::Node
+{
+public:
+  ToolPathPlannerServer() : Node("tool_path_planner_server")
+  {
+    using namespace std::placeholders;
+    service_ = this->create_service<noether_tpp_server::srv::PlanToolPath>(
+        "plan_tool_path",
+        std::bind(&ToolPathPlannerServer::callback, this, _1, _2));
+  }
+
+private:
+  void callback(const std::shared_ptr<noether_tpp_server::srv::PlanToolPath::Request> req,
+                std::shared_ptr<noether_tpp_server::srv::PlanToolPath::Response> res)
+  {
+    try
+    {
+      // Load mesh
+      pcl::PolygonMesh mesh;
+      if (pcl::io::loadPolygonFile(req->mesh_file, mesh) < 1)
+        throw std::runtime_error("Failed to load mesh");
+
+      // Build pipeline
+      boost_plugin_loader::PluginLoader loader;
+      loader.search_libraries.insert(NOETHER_GUI_PLUGINS);
+      loader.search_libraries_env = NOETHER_GUI_PLUGIN_LIBS_ENV;
+      loader.search_paths_env = NOETHER_GUI_PLUGIN_PATHS_ENV;
+      noether::ConfigurableTPPPipelineWidget widget(std::move(loader));
+      widget.configure(YAML::LoadFile(req->config_file));
+      noether::ToolPathPlannerPipeline pipeline = widget.createPipeline();
+
+      // Run pipeline
+      std::vector<pcl::PolygonMesh> meshes = pipeline.mesh_modifier->modify(mesh);
+      std::vector<noether::ToolPaths> paths;
+      paths.reserve(meshes.size());
+      for (const auto& m : meshes)
+      {
+        noether::ToolPaths tp = pipeline.planner->plan(m);
+        paths.push_back(pipeline.tool_path_modifier->modify(tp));
+      }
+
+      YAML::Node yaml = toYaml(paths);
+      std::ofstream ofh(req->output_file);
+      if (!ofh)
+        throw std::runtime_error("Failed to open output file");
+      ofh << yaml;
+      res->yaml = YAML::Dump(yaml);
+      res->success = true;
+    }
+    catch (const std::exception& ex)
+    {
+      RCLCPP_ERROR(this->get_logger(), "Planning failed: %s", ex.what());
+      res->success = false;
+      res->yaml = "";
+    }
+  }
+
+  rclcpp::Service<noether_tpp_server::srv::PlanToolPath>::SharedPtr service_;
+};
+
+}  // namespace noether_tpp_server
+
+int main(int argc, char** argv)
+{
+  QApplication app(argc, argv);
+  rclcpp::init(argc, argv);
+  auto node = std::make_shared<noether_tpp_server::ToolPathPlannerServer>();
+  rclcpp::spin(node);
+  rclcpp::shutdown();
+  return 0;
+}

--- a/noether_tpp_server/srv/PlanToolPath.srv
+++ b/noether_tpp_server/srv/PlanToolPath.srv
@@ -1,0 +1,6 @@
+string mesh_file
+string config_file
+string output_file
+---
+bool success
+string yaml


### PR DESCRIPTION
## Summary
- create new package `noether_tpp_server`
- define ROS2 service `PlanToolPath`
- implement service node to plan toolpaths using existing GUI pipeline code and write results to YAML
- fix rosidl interface package declaration

## Testing
- `./.run-clang-format` *(fails: `clang-format-14` not found)*
- `colcon build --packages-select noether_tpp_server` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_684681921fa08320b019a144c6b29b29